### PR TITLE
Add Cogitare

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Awesome-Pytorch-list
 37. [pytorchviz](https://github.com/szagoruyko/pytorchviz): A small package to create visualizations of PyTorch execution graphs. 
 38. [cogitare](https://github.com/cogitare-ai/cogitare): Cogitare - A Modern, Fast, and Modular Deep Learning and Machine Learning framework in Python. 
 39. [pydlt](https://github.com/dmarnerides/pydlt): PyTorch based Deep Learning Toolbox
+40. [Cogitare](https://github.com/cogitare-ai/cogitare): A Modern, Fast, and Modular Deep Learning and Machine Learning framework for Python. 
 
 
 


### PR DESCRIPTION
Add Cogitare, a deep learning framework built on top of PyTorch.

Docs: http://docs.cogitare-ai.org/
Tutorials: http://tutorials.cogitare-ai.org/