### PR TITLE
Add Intro to Deep Learning with PyTorch

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ This library contains a PyTorch implementation of the SO(3) equivariant CNNs for
 56. [mri-analysis-pytorch](https://github.com/omarsar/mri-analysis-pytorch): MRI analysis using PyTorch and MedicalTorch
 57. [cifar10-fast](https://github.com/davidcpage/cifar10-fast): 
 Demonstration of training a small ResNet on CIFAR10 to 94% test accuracy in 79 seconds as described in this [blog series](https://www.myrtle.ai/2018/09/24/how_to_train_your_resnet/).
+58. [Intro to Deep Learning with PyTorch](https://in.udacity.com/course/deep-learning-pytorch--ud188): A free course by Udacity and facebook, with a good intro to PyTorch, and an interview with Soumith Chintala, one of the original authors of PyTorch.
 
 ## Paper implementations
 


### PR DESCRIPTION
Add "Intro to Deep Learning with PyTorch", a free course by Udacity and Facebook AI, which uses PyTorch to implement deep neural networks. It also has an interview by Soumith Chintala, one of the creators of PyTorch. It covers an Intro to PyTorch, and also a tutorial for deploying it to C++.