### PR TITLE
Added albumentations library

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ This library contains a PyTorch implementation of the SO(3) equivariant CNNs for
 15. [maskrcnn-benchmark](https://github.com/facebookresearch/maskrcnn-benchmark): Fast, modular reference implementation of Instance Segmentation and Object Detection algorithms in PyTorch.
 16. [image-classification-mobile](https://github.com/osmr/imgclsmob): Collection of classification models pretrained on the ImageNet-1K.
 17. [medicaltorch](https://github.com/perone/medicaltorch): A medical imaging framework for Pytorch http://medicaltorch.readthedocs.io
+18. [albumentations](https://github.com/albu/albumentations): Fast image augmentation library.
 
 ### Probabilistic/Generative Libraries:
 


### PR DESCRIPTION
I am proposing to add Albumentations library to the list. https://github.com/albu/albumentations

The library is used in many companies for Computer Vision tasks
And in a Computer Vision competitions at kaggle.com and other platforms.

It is actively maintained and new features are added on a regular basis. The repo currently has 2000+ stars.

I think it would be a great addition to the `awesome-pytorch-list`.