### PR TITLE
Add Poutyne library for PyTorch

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ This library contains a PyTorch implementation of the SO(3) equivariant CNNs for
 137. [PyTorch-VAE](https://github.com/AntixK/PyTorch-VAE): A Collection of Variational Autoencoders (VAE) in PyTorch.
 138. [ray](https://github.com/ray-project/ray): A fast and simple framework for building and running distributed applications. Ray is packaged with RLlib, a scalable reinforcement learning library, and Tune, a scalable hyperparameter tuning library. ray.io
 139. [Pytorch Geometric Temporal](https://github.com/benedekrozemberczki/pytorch_geometric_temporal): A temporal extension library for PyTorch Geometric 
+140. [Poutyne](https://github.com/GRAAL-Research/poutyne): A Keras-like framework for PyTorch that handles much of the boilerplating code needed to train neural networks. 
 
 ## Tutorials, books, & examples
 


### PR DESCRIPTION
Poutyne is a Keras-like framework for PyTorch and handles much of the boilerplating code needed to train neural networks.

Use Poutyne to:

Train models easily.
Use callbacks to save your best model, perform early stopping and much more.

