### PR TITLE
Add Captum to Pytorch & related libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Awesome-Pytorch-list
 ## Pytorch & related libraries
 
 1. [pytorch](http://pytorch.org): Tensors and Dynamic neural networks in Python with strong GPU acceleration.
+2. [Captum](https://github.com/pytorch/captum): Model interpretability and understanding for PyTorch.
 
 ### NLP & Speech Processing:
 


### PR DESCRIPTION
Captum is one of the official PyTorch libraries, so I placed it under the link for the main PyTorch library. Let me know if I need to change anything!