### PR TITLE
Added einops in Other libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ This library contains a PyTorch implementation of the SO(3) equivariant CNNs for
 153. [Pytorch Geometric Signed Directed](https://github.com/SherylHYX/pytorch_geometric_signed_directed): A signed and directed extension library for PyTorch Geometric. 
 154. [Koila](https://github.com/rentruewang/koila): A simple wrapper around pytorch that prevents CUDA out of memory issues.
 155. [Renate](https://github.com/awslabs/renate): A library for real-world continual learning.
+156. [einops](https://github.com/arogozhnikov/einops): A tool inspired by Einstein notation to make tensor operations more readable.
 
 ## Tutorials, books, & examples
 


### PR DESCRIPTION
Added [einops](https://github.com/arogozhnikov/einops), a tool inspired by Einstein notation to make tensor operations more readable.