### PR TITLE
Add a link to Torch Geopooling library

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ This library contains a PyTorch implementation of the SO(3) equivariant CNNs for
 153. [Pytorch Geometric Signed Directed](https://github.com/SherylHYX/pytorch_geometric_signed_directed): A signed and directed extension library for PyTorch Geometric. 
 154. [Koila](https://github.com/rentruewang/koila): A simple wrapper around pytorch that prevents CUDA out of memory issues.
 155. [Renate](https://github.com/awslabs/renate): A library for real-world continual learning.
+156. [Torch Geopooling](https://github.com/ybubnov/torch_geopooling): The geospatial pooling modules for neural networks in PyTorch.
 
 ## Tutorials, books, & examples
 


### PR DESCRIPTION
This patch extends a section "Other libraries" in README.md and adds a reference to a PyTorch extension that implements modules for geospatial machine learning.