### PR TITLE
Add TorchDR to Other libraries section

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ This library contains a PyTorch implementation of the SO(3) equivariant CNNs for
 153. [Pytorch Geometric Signed Directed](https://github.com/SherylHYX/pytorch_geometric_signed_directed): A signed and directed extension library for PyTorch Geometric. 
 154. [Koila](https://github.com/rentruewang/koila): A simple wrapper around pytorch that prevents CUDA out of memory issues.
 155. [Renate](https://github.com/awslabs/renate): A library for real-world continual learning.
+156. [TorchDR](https://github.com/TorchDR/TorchDR): GPU-accelerated dimensionality reduction library for PyTorch with scikit-learn-compatible API. Includes implementations of UMAP, t-SNE, PCA, and more.
 
 ## Tutorials, books, & examples
 


### PR DESCRIPTION
## Summary

Add TorchDR to the Other libraries section. TorchDR provides GPU and multi-GPU dimensionality reduction for PyTorch through a scikit-learn-compatible API, including UMAP, t-SNE, PACMAP, PHATE, and PCA.

## Validation

- [x] Rebased the contribution onto the current upstream list without force-pushing
- [x] Verified the project link
- [x] Checked the Markdown diff for whitespace errors