### PR TITLE
Add FreeGrad library

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,8 @@ This library contains a PyTorch implementation of the SO(3) equivariant CNNs for
 153. [Pytorch Geometric Signed Directed](https://github.com/SherylHYX/pytorch_geometric_signed_directed): A signed and directed extension library for PyTorch Geometric. 
 154. [Koila](https://github.com/rentruewang/koila): A simple wrapper around pytorch that prevents CUDA out of memory issues.
 155. [Renate](https://github.com/awslabs/renate): A library for real-world continual learning.
+156. [FreeGrad](https://github.com/tbox98/FreeGrad) - PyTorch library for custom backward passes, straight-through estimators and gradient transforms.
+
 
 ## Tutorials, books, & examples
 

--- a/README.md
+++ b/README.md
@@ -281,8 +281,6 @@ This library contains a PyTorch implementation of the SO(3) equivariant CNNs for
 153. [Pytorch Geometric Signed Directed](https://github.com/SherylHYX/pytorch_geometric_signed_directed): A signed and directed extension library for PyTorch Geometric. 
 154. [Koila](https://github.com/rentruewang/koila): A simple wrapper around pytorch that prevents CUDA out of memory issues.
 155. [Renate](https://github.com/awslabs/renate): A library for real-world continual learning.
-156. [FreeGrad](https://github.com/tbox98/FreeGrad) - PyTorch library for custom backward passes, straight-through estimators and gradient transforms.
-
 
 ## Tutorials, books, & examples
 
@@ -710,6 +708,8 @@ Janai, J., Güney, F., Ranjan, A., Black, M. and Geiger, A., Unsupervised Learni
 343. [SSSNET](https://github.com/SherylHYX/SSSNET_Signed_Clustering): Official implementation of the SDM2022 paper "SSSNET: Semi-Supervised Signed Network Clustering".
 344. [MagNet](https://github.com/matthew-hirn/magnet): Official implementation of the NeurIPS2021 paper "MagNet: A Neural Network for Directed Graphs".
 345. [Semantic Search](https://github.com/kuutsav/information-retrieval): Latest in the field of neural information retrieval / semantic search.
+346. [FreeGrad](https://github.com/tbox98/FreeGrad) - PyTorch library for custom backward passes, straight-through estimators and gradient transforms.
+
 
 ## Talks & conferences
 


### PR DESCRIPTION
FreeGrad is a PyTorch extension for experimenting with alternative backward rules and gradient transforms on top of standard autograd. It lets you plug in custom backward rules (e.g. STE-like tricks, gradient jamming, custom clipping), decouple forward activations from backward passes, and prototype research ideas on learning dynamics without forking or patching PyTorch.