### PR TITLE
Add output-shape to Other libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ This library contains a PyTorch implementation of the SO(3) equivariant CNNs for
 154. [Koila](https://github.com/rentruewang/koila): A simple wrapper around pytorch that prevents CUDA out of memory issues.
 155. [Renate](https://github.com/awslabs/renate): A library for real-world continual learning.
 156. [ANEE](https://github.com/abkmystery/ANEE) – Adaptive Neural Execution Engine for PyTorch transformers. Provides per-token dynamic layer skipping, profiler-based gating, and KV-cache-safe sparse inference.
+157. [output-shape](https://github.com/avocardio/output-shape): A lightweight shape debugger for PyTorch. One decorator on forward() to trace module paths, output shapes, and dtypes through any model.
 
 
 ## Tutorials, books, & examples


### PR DESCRIPTION
Adds [output-shape](https://github.com/avocardio/output-shape) to the Other libraries section.

A lightweight shape debugger for PyTorch — one decorator on `forward()` to trace module paths, output shapes, and dtypes through any model.

- PyPI: https://pypi.org/project/output-shape/
- MIT licensed
- Zero dependencies beyond PyTorch