### PR TITLE
Add zij

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ This library contains a PyTorch implementation of the SO(3) equivariant CNNs for
 154. [Koila](https://github.com/rentruewang/koila): A simple wrapper around pytorch that prevents CUDA out of memory issues.
 155. [Renate](https://github.com/awslabs/renate): A library for real-world continual learning.
 156. [ANEE](https://github.com/abkmystery/ANEE) – Adaptive Neural Execution Engine for PyTorch transformers. Provides per-token dynamic layer skipping, profiler-based gating, and KV-cache-safe sparse inference.
+157. [zij](https://github.com/junaidaliop/zij): A canon of deep learning optimization algorithms.
 
 
 ## Tutorials, books, & examples


### PR DESCRIPTION
Adds zij to the Other libraries section. zij is a catalog and PyTorch library of deep learning optimizers (install via `pip install zij`): https://github.com/junaidaliop/zij